### PR TITLE
escape % in app log

### DIFF
--- a/runner/logger.go
+++ b/runner/logger.go
@@ -35,7 +35,7 @@ func fatal(err error) {
 type appLogWriter struct{}
 
 func (a appLogWriter) Write(p []byte) (n int, err error) {
-	appLog(string(p))
+	appLog(strings.Replace(string(p), "%", "%%", -1))
 
 	return len(p), nil
 }


### PR DESCRIPTION
if app log output has '%', the console output will be something like: %!E(MISSING)4%!B(MISSING)8%!A(MISSING)